### PR TITLE
Markdown as raw string to fix latex

### DIFF
--- a/streambook/gen.py
+++ b/streambook/gen.py
@@ -28,7 +28,7 @@ class Generate:
 
     def markdown(self, source):
         self.all_markdown += source + "\n"
-        self.gen('__st.markdown("""%s""")' % source)
+        self.gen('__st.markdown(r"""%s""")' % source)
 
     def code(self, source):
         wrapper = textwrap.TextWrapper(


### PR DESCRIPTION
This fixes the latex errors. As an example try this:
```python
# %% [markdown]
"""
$$ 
\Delta G = \Delta\sigma \frac{a}{b} 
$$ 
"""
```